### PR TITLE
Change dockerfile to always use latest version of instantclient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM node:18.12.1-bullseye-slim
 # hadolint ignore=DL3008
-ARG INSTANT_CLIENT=https://download.oracle.com/otn_software/linux/instantclient/211000/instantclient-basiclite-linux.x64-21.1.0.0.0.zip
-ARG INSTANT_CLIENT_LOCATION=/opt/oracle/instantclient_21_1
+ARG INSTANT_CLIENT=https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linuxx64.zip
+ARG INSTANT_CLIENT_LOCATION=/opt/oracle/instantclient
 # hadolint ignore=DL3008
 RUN apt-get update && \
   apt-get -y --no-install-recommends install libaio1 curl ca-certificates unzip && \
   mkdir /opt/oracle && \
   curl -L ${INSTANT_CLIENT} -o /tmp/instantclient.zip && \
   unzip /tmp/instantclient.zip -d /opt/oracle && \
+  mv /opt/oracle/instant* ${INSTANT_CLIENT_LOCATION} && \
+  rm /tmp/*.zip && \
   chown -R node:node ${INSTANT_CLIENT_LOCATION} && \
   echo ${INSTANT_CLIENT_LOCATION} > /etc/ld.so.conf.d/oracle-instantclient.conf && \
   ldconfig && \


### PR DESCRIPTION
This will also autoupgrade to whatever major version is the most fresh too. I assume we still want that, in most cases.

Signed-off-by: Kristian Berg <kristian.berg@tietoevry.com>